### PR TITLE
Pass AdHoc Runtime parameters

### DIFF
--- a/src/upgini/dataset.py
+++ b/src/upgini/dataset.py
@@ -30,6 +30,7 @@ from upgini.metadata import (
     NumericInterval,
     RegressionTask,
     SearchCustomization,
+    RuntimeParameters,
 )
 from upgini.search_task import SearchTask
 from upgini.normalizer.phone_normalizer import phone_to_int
@@ -608,9 +609,13 @@ class Dataset(pd.DataFrame):
         extract_features: bool,
         accurate_model: Optional[bool] = None,
         filter_features: Optional[dict] = None,
+        runtime_parameters: Optional[RuntimeParameters] = None,
     ) -> SearchCustomization:
         search_customization = SearchCustomization(
-            extractFeatures=extract_features, accurateModel=accurate_model, returnScores=return_scores
+            extractFeatures=extract_features,
+            accurateModel=accurate_model,
+            returnScores=return_scores,
+            runtimeParameters=runtime_parameters,
         )
         if filter_features:
             if [
@@ -638,6 +643,7 @@ class Dataset(pd.DataFrame):
         extract_features: bool = False,
         accurate_model: bool = False,
         filter_features: Optional[dict] = None,
+        runtime_parameters: Optional[RuntimeParameters] = None,
     ) -> SearchTask:
 
         if self.etalon_def is None:
@@ -650,7 +656,11 @@ class Dataset(pd.DataFrame):
 
         file_metadata = self.__construct_metadata()
         search_customization = self.__construct_search_customization(
-            return_scores, extract_features, accurate_model, filter_features
+            return_scores=return_scores,
+            extract_features=extract_features,
+            accurate_model=accurate_model,
+            filter_features=filter_features,
+            runtime_parameters=runtime_parameters,
         )
 
         if self.file_upload_id is not None and get_rest_client(self.endpoint, self.api_key).check_uploaded_file_v2(
@@ -682,7 +692,11 @@ class Dataset(pd.DataFrame):
         return search_task.poll_result()
 
     def validation(
-        self, initial_search_task_id: str, return_scores: bool = True, extract_features: bool = False
+        self,
+        initial_search_task_id: str,
+        return_scores: bool = True,
+        extract_features: bool = False,
+        runtime_parameters: Optional[RuntimeParameters] = None,
     ) -> SearchTask:
         if self.etalon_def is None:
             self.validate(validate_target=not extract_features, validate_count=False)
@@ -696,7 +710,9 @@ class Dataset(pd.DataFrame):
             self.drop(["is_valid"], axis=1, inplace=True)
 
         file_metadata = self.__construct_metadata()
-        search_customization = self.__construct_search_customization(return_scores, extract_features)
+        search_customization = self.__construct_search_customization(
+            return_scores, extract_features, runtime_parameters=runtime_parameters
+        )
 
         if self.file_upload_id is not None and get_rest_client(self.endpoint, self.api_key).check_uploaded_file_v2(
             self.file_upload_id, file_metadata

--- a/src/upgini/http.py
+++ b/src/upgini/http.py
@@ -16,10 +16,12 @@ from upgini.metadata import FileMetadata, FileMetrics, SearchCustomization
 
 try:
     from importlib_metadata import version
+
     __version__ = version("upgini")
 except ImportError:
     try:
         from importlib.metadata import version
+
         __version__ = version("upgini")
     except ImportError:
         __version__ = "Upgini wasn't installed"

--- a/src/upgini/metadata.py
+++ b/src/upgini/metadata.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from pydantic import BaseModel
 
@@ -123,16 +123,22 @@ class FeaturesFilter(BaseModel):
     selectedFeatures: Optional[List[str]]
 
 
+class RuntimeParameters(BaseModel):
+    properties: Optional[Dict[str, str]]
+
+
 class SearchCustomization(BaseModel):
     featuresFilter: Optional[FeaturesFilter]
     extractFeatures: Optional[bool]
     accurateModel: Optional[bool]
     returnScores: Optional[bool]
+    runtimeParameters: Optional[RuntimeParameters]
 
     def __repr__(self):
         return (
             f"Features filter: {self.featuresFilter}, "
             f"extract features: {self.extractFeatures}, "
             f"accurate model: {self.accurateModel}, "
-            f"return scores: {self.returnScores}"
+            f"return scores: {self.returnScores}, "
+            f"runtimeParameters: {self.runtimeParameters}"
         )

--- a/src/upgini/search_task.py
+++ b/src/upgini/search_task.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from upgini import dataset
 from upgini.http import ProviderTaskSummary, SearchTaskSummary, get_rest_client
-from upgini.metadata import SYSTEM_RECORD_ID, ModelTaskType
+from upgini.metadata import SYSTEM_RECORD_ID, ModelTaskType, RuntimeParameters
 
 
 class SearchTask:
@@ -109,8 +109,18 @@ class SearchTask:
             else:
                 return "Internal error"
 
-    def validation(self, validation_dataset: "dataset.Dataset", extract_features: bool = False) -> "SearchTask":
-        return validation_dataset.validation(self.search_task_id, return_scores=True, extract_features=extract_features)
+    def validation(
+        self,
+        validation_dataset: "dataset.Dataset",
+        extract_features: bool = False,
+        runtime_parameters: Optional[RuntimeParameters] = None,
+    ) -> "SearchTask":
+        return validation_dataset.validation(
+            self.search_task_id,
+            return_scores=True,
+            extract_features=extract_features,
+            runtime_parameters=runtime_parameters,
+        )
 
     def _check_finished_initial_search(self) -> List[ProviderTaskSummary]:
         if self.summary is None or len(self.summary.initial_important_providers) == 0:
@@ -119,7 +129,7 @@ class SearchTask:
 
     def _check_finished_validation_search(self) -> List[ProviderTaskSummary]:
         if self.summary is None or len(self.summary.validation_important_providers) == 0:
-            raise RuntimeError("Validation search didn't start.")
+            raise RuntimeError(f"Validation search didn't start. summary: {self.summary}")
         return self.summary.validation_important_providers
 
     @staticmethod

--- a/tests/test_features_enricher.py
+++ b/tests/test_features_enricher.py
@@ -3,6 +3,8 @@ import os
 import pandas as pd
 
 from upgini import FeaturesEnricher, SearchKey
+from upgini.metadata import RuntimeParameters
+from requests_mock.mocker import Mocker
 
 
 def test_features_enricher(requests_mock):
@@ -105,3 +107,194 @@ def test_features_enricher(requests_mock):
     )
 
     assert metrics is not None and metrics.equals(expected_metrics)
+
+
+def test_features_enricher_fit_transform_runtime_parameters(requests_mock: Mocker):
+    url = "http://fake_url2"
+    path_to_mock_features = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "test_data/binary/mock_features.csv.gz"
+    )
+    requests_mock.post(url + "/private/api/v2/security/refresh_access_token", json={"access_token": "123"})
+    requests_mock.post(
+        url + "/public/api/v2/search/initial",
+        json={
+            "fileUploadId": "123",
+            "searchTaskId": "initialSearchTaskId",
+            "searchType": "INITIAL",
+            "status": "SUBMITTED",
+            "extractFeatures": "true",
+            "returnScores": "false",
+            "createdAt": 1633302145414,
+        },
+    )
+    requests_mock.get(
+        url + "/public/api/v2/search/initialSearchTaskId",
+        json={
+            "fileUploadTaskId": "123",
+            "searchTaskId": "initialSearchTaskId",
+            "searchTaskStatus": "COMPLETED",
+            "featuresFoundCount": 1,
+            "providersCheckedCount": 1,
+            "importantProvidersCount": 1,
+            "importantFeaturesCount": 1,
+            "importantProviders": [
+                {
+                    "adsSearchTaskId": "432",
+                    "searchTaskId": "initialSearchTaskId",
+                    "searchType": "INITIAL",
+                    "taskStatus": "COMPLETED",
+                    "providerName": "Provider-123456",
+                    "providerId": "123456",
+                    "providerQuality": {
+                        "metrics": [
+                            {"code": "HIT_RATE", "value": 99.9},
+                            {"code": "AUC", "value": 0.66},
+                            {"code": "UPLIFT", "value": 0.1},
+                        ]
+                    },
+                    "featuresFoundCount": 1,
+                    "evalSetMetrics": [
+                        {"eval_set_index": 1, "hit_rate": 100, "auc": 0.5},
+                        {"eval_set_index": 2, "hit_rate": 99, "auc": 0.77},
+                    ],
+                }
+            ],
+            "validationImportantProviders": [],
+            "createdAt": 1633302145414,
+        },
+    )
+    requests_mock.get(
+        url + "/public/api/v2/search/rawfeatures/initialSearchTaskId",
+        json={"adsSearchTaskFeaturesDTO": [{"searchType": "INITIAL", "adsSearchTaskFeaturesId": "333"}]},
+    )
+    with open(path_to_mock_features, "rb") as f:
+        buffer = f.read()
+        requests_mock.get(url + "/public/api/v2/search/rawfeatures/333/file", content=buffer)
+
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data/binary/data.csv")
+    df = pd.read_csv(path, sep=",")
+    train_df = df.head(10000)
+    train_features = train_df.drop(columns="target")
+    train_target = train_df["target"]
+    eval1_df = df[10000:11000]
+    eval1_features = eval1_df.drop(columns="target")
+    eval1_target = eval1_df["target"]
+    eval2_df = df[11000:12000]
+    eval2_features = eval2_df.drop(columns="target")
+    eval2_target = eval2_df["target"]
+
+    enricher = FeaturesEnricher(
+        search_keys={"phone_num": SearchKey.PHONE, "rep_date": SearchKey.DATE},
+        keep_input=True,
+        accurate_model=True,
+        endpoint=url,
+        api_key="fake_api_key",
+        runtime_parameters=RuntimeParameters(properties={"runtimeProperty1": "runtimeValue1"}),
+    )
+    assert enricher.runtime_parameters is not None
+
+    enricher.fit(
+        train_features, train_target, eval_set=[(eval1_features, eval1_target), (eval2_features, eval2_target)]
+    )
+
+    fit_req = None
+    initial_search_url = "http://fake_url2/public/api/v2/search/initial"
+    for elem in requests_mock.request_history:
+        if elem.url == initial_search_url:
+            fit_req = elem
+
+    # TODO: can be better with https://metareal.blog/en/post/2020/05/03/validating-multipart-form-data-with-requests-mock/
+    # It's do-able to parse req with cgi module and verify contents
+    assert fit_req is not None
+    assert "runtimeProperty1" in str(fit_req.body)
+    assert "runtimeValue1" in str(fit_req.body)
+
+    requests_mock.post(
+        url + "/public/api/v2/search/validation?initialSearchTaskId=initialSearchTaskId",
+        json={
+            "fileUploadId": "validation_fileUploadId",
+            "searchTaskId": "validation_searchTaskId",
+            "searchType": "VALIDATION",
+            "status": "SUBMITTED",
+            "extractFeatures": "true",
+            "returnScores": "false",
+            "createdAt": 1633302145414,
+        },
+    )
+
+    requests_mock.get(
+        url + "/public/api/v2/search/initialSearchTaskId",
+        json={
+            "fileUploadTaskId": "validation_fileUploadTaskId",
+            "searchTaskId": "validation_searchTaskId",
+            "searchTaskStatus": "COMPLETED",
+            "featuresFoundCount": 1,
+            "providersCheckedCount": 1,
+            "importantProvidersCount": 1,
+            "importantFeaturesCount": 1,
+            "importantProviders": [
+                {
+                    "adsSearchTaskId": "adsSearchTaskId_initial",
+                    "searchTaskId": "321",
+                    "searchType": "INITIAL",
+                    "taskStatus": "COMPLETED",
+                    "providerName": "Provider-123456",
+                    "providerId": "123456",
+                    "providerQuality": {
+                        "metrics": [
+                            {"code": "HIT_RATE", "value": 99.9},
+                            {"code": "AUC", "value": 0.66},
+                            {"code": "UPLIFT", "value": 0.1},
+                        ]
+                    },
+                    "featuresFoundCount": 1,
+                    "evalSetMetrics": [
+                        {"eval_set_index": 1, "hit_rate": 100, "auc": 0.5},
+                        {"eval_set_index": 2, "hit_rate": 99, "auc": 0.77},
+                    ],
+                }
+            ],
+            "validationImportantProviders": [
+                {
+                    "adsSearchTaskId": "adsSearchTaskIdЗ_validation",
+                    "searchTaskId": "validation_searchTaskId",
+                    "searchType": "VALIDATION",
+                    "taskStatus": "VALIDATION_COMPLETED",
+                    "providerName": "Provider-123456",
+                    "providerId": "123456",
+                    "providerQuality": {
+                        "metrics": [
+                            {"code": "HIT_RATE", "value": 99.9},
+                            {"code": "AUC", "value": 0.66},
+                            {"code": "UPLIFT", "value": 0.1},
+                        ]
+                    },
+                    "featuresFoundCount": 1,
+                    "evalSetMetrics": [
+                        {"eval_set_index": 1, "hit_rate": 100, "auc": 0.5},
+                        {"eval_set_index": 2, "hit_rate": 99, "auc": 0.77},
+                    ],
+                }
+            ],
+            "createdAt": 1633302145414,
+        },
+    )
+
+    requests_mock.get(
+        url + "/public/api/v2/search/rawfeatures/validation_searchTaskId",
+        json={"adsSearchTaskFeaturesDTO": [{"searchType": "VALIDATION", "adsSearchTaskFeaturesId": "333"}]},
+    )
+
+    transformed = enricher.transform(train_features)
+
+    transform_req = None
+    transform_url = "http://fake_url2/public/api/v2/search/validation?initialSearchTaskId=initialSearchTaskId"
+    for elem in requests_mock.request_history:
+        if elem.url == transform_url:
+            transform_req = elem
+
+    assert transform_req is not None
+    assert "runtimeProperty1" in str(transform_req.body)
+    assert "runtimeValue1" in str(transform_req.body)
+
+    assert transformed.shape == (10000, 5)

--- a/tests/test_features_enricher.py
+++ b/tests/test_features_enricher.py
@@ -203,7 +203,8 @@ def test_features_enricher_fit_transform_runtime_parameters(requests_mock: Mocke
         if elem.url == initial_search_url:
             fit_req = elem
 
-    # TODO: can be better with https://metareal.blog/en/post/2020/05/03/validating-multipart-form-data-with-requests-mock/
+    # TODO: can be better with
+    #  https://metareal.blog/en/post/2020/05/03/validating-multipart-form-data-with-requests-mock/
     # It's do-able to parse req with cgi module and verify contents
     assert fit_req is not None
     assert "runtimeProperty1" in str(fit_req.body)


### PR DESCRIPTION
Problem:
Improve time to market for experimental features. 

Solution:
Allow users to pass ad-hoc RuntimeParameters to trigger experimental features at backend side.
Backend accepts RuntimeParameters as a part of SearchCustomization. RuntimeParameters is a Dict[str, str] literally.
It's Backend responsibility to react on RuntimeParameters. 

Auditory:
Developers, advanced users involved in features testing.