### PR TITLE
# Support a custom backend URL and disabled auth via env vars

### DIFF
--- a/src/upgini/http.py
+++ b/src/upgini/http.py
@@ -316,7 +316,13 @@ class _RestClient:
         # self.silent_mode = silent_mode
         self.client_ip = client_ip
         self.client_visitorid = client_visitorid
-        self._access_token = self._refresh_access_token()
+        # If UPGINI_NO_AUTH is set, skip the refresh_access_token exchange entirely and
+        # use the configured token as-is for the Authorization header. For use against
+        # an ADSM deployment running with auth/authz disabled (e.g. an air-gapped
+        # internal installation).
+        self._access_token = (
+            self._refresh_token if os.environ.get("UPGINI_NO_AUTH") else self._refresh_access_token()
+        )
         # self._access_token: Optional[str] = None  # self._refresh_access_token()
         self.last_refresh_time = time.time()
 


### PR DESCRIPTION
Two opt-in environment variables for pointing the client at a non-default ADSM deployment — useful for local development or testing against an internal/air-gapped instance:

- `UPGINI_URL` (already existed) — overrides the backend base URL instead of the public SaaS endpoint.
- `UPGINI_NO_AUTH` (new) — skips the OAuth token-refresh exchange and uses the configured token as-is, for use against an ADSM instance running with auth disabled.

Both are unset by default; behavior is unchanged unless you explicitly set them.

## Usage (Jupyter notebook)

```python
import os

os.environ["UPGINI_URL"] = "http://localhost:8080"
os.environ["UPGINI_NO_AUTH"] = "1"

from upgini import FeaturesEnricher, SearchKey

enricher = FeaturesEnricher(search_keys={"date": SearchKey.DATE})
# ... enricher.fit(X, y) / enricher.transform(X) now talk to localhost:8080, no auth
```